### PR TITLE
feat: implement delightful UX interaction improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,7 +28,14 @@
   gap: 16px;
   pointer-events: none;
   z-index: 5;
-  animation: fadeOutAfterDelay 12s forwards;
+  transition: opacity 1s cubic-bezier(0.2, 0.8, 0.2, 1), visibility 1s cubic-bezier(0.2, 0.8, 0.2, 1);
+  opacity: 1;
+  visibility: visible;
+}
+
+.discovery-cue.fade-out {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .scroll-indicator {
@@ -82,7 +89,3 @@
   50% { opacity: 0.7; }
 }
 
-@keyframes fadeOutAfterDelay {
-  0%, 80% { visibility: visible; opacity: 1; }
-  100% { visibility: hidden; opacity: 0; }
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ function App() {
   const { isLoading, error, fetchDestinations } = useDestinationStore();
   const [visible, setVisible] = useState(false);
   const [oculusVisible, setOculusVisible] = useState(false);
+  const [hasInteracted, setHasInteracted] = useState(false);
 
   useEffect(() => {
     analytics.init();
@@ -63,6 +64,22 @@ function App() {
     }
   }, [isLoading, error]);
 
+  useEffect(() => {
+    const handleInteraction = () => {
+      setHasInteracted(true);
+    };
+
+    window.addEventListener('wheel', handleInteraction, { once: true });
+    window.addEventListener('keydown', handleInteraction, { once: true });
+    window.addEventListener('pointerdown', handleInteraction, { once: true });
+
+    return () => {
+      window.removeEventListener('wheel', handleInteraction);
+      window.removeEventListener('keydown', handleInteraction);
+      window.removeEventListener('pointerdown', handleInteraction);
+    };
+  }, []);
+
   if (!hasWebGL) {
     return <NoWebGLFallback />;
   }
@@ -94,7 +111,7 @@ function App() {
 
       {/* Discovery Cue */}
       {visible && (
-        <div className="discovery-cue">
+        <div className={`discovery-cue ${hasInteracted ? 'fade-out' : ''}`}>
           <div className="scroll-indicator">
             <div className="scroll-dot" />
           </div>

--- a/src/components/Destination.tsx
+++ b/src/components/Destination.tsx
@@ -96,6 +96,7 @@ export const Destination = ({ destination }: { destination: DestinationType }) =
       <mesh
         ref={meshRef}
         position={destination.coordinates}
+        onClick={() => handleDestinationClick(destination)}
         onPointerOver={() => setHoveredDestination(destination.id)}
         onPointerOut={() => setHoveredDestination(null)}
       >


### PR DESCRIPTION
# Delightful UX Transformer Redesign

Implemented actionable improvements to create a more delightful and premium UX, following the First Principles UX Analysis:

### 1. The Cinematic Awakening
**Concept:** Make the initial load feel like waking up in a new world, trusting the user to remember the interaction model.
**Interaction design:** The "Scroll to Explore" text fades away permanently once the user takes their first action (scroll, keydown, click), transitioning from a passive view to active exploration.
**Visual technique:** A state-driven CSS class `fade-out` smoothly transitions opacity and visibility out using an eased 1-second curve.
**Why it creates a "wow moment":** It instantly shifts the experience from a guided website into an immersive environment, increasing the sense of "Mastery" as the interface reacts directly to the user's awakening actions rather than an arbitrary 12-second timer.

### 2. Interaction Design - Click Exploration
**Concept:** Clicking doesn't jump the camera; it smoothly lerps the camera deeper into the scene, letting the destination fill the screen while the background falls into profound depth-of-field blur.
**Interaction design:** Added a direct `onClick` event to the destination geometries, complementing the existing hover states.
**Visual technique:** Calls `setCameraTargetZ` via `handleDestinationClick` to trigger the application's built-in smooth camera interpolation mechanics. 
**Why it creates a "wow moment":** The physical feeling of zooming in rather than "loading a new page" maintains "Flow" and deepens immersion by anchoring UI interactions entirely within the 3D space.

---
*PR created automatically by Jules for task [3329153478270526363](https://jules.google.com/task/3329153478270526363) started by @rajeshceg3*